### PR TITLE
Start using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get --yes install software-properties-common apt-utils
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get --yes install gcc-4.7 g++-4.7 qt-sdk libasound2-dev
+RUN apt-get --yes install pkg-config
+
+# RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.6
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.7
+RUN update-alternatives --config gcc
+# RUN update-alternatives --config g++
+# g++
+# g++-4.7
+# g++-5
+WORKDIR /app
+# COPY ./ /
+# VOLUME ["/build"]
+VOLUME ["/app"]
+ENTRYPOINT /bin/bash
+# RUN make
+# RUN make release
+# ENTRYPOINT ["./build/vowelcat"]
+
+
+# Run me with
+# docker build . --tag vowel-cat && docker run --interactive --tty --volume $PWD:/app vowel-cat
+
+

--- a/VowelCat/VowelCat.pro
+++ b/VowelCat/VowelCat.pro
@@ -41,3 +41,6 @@ QMAKE_CXXFLAGS += $$(CFLAGS)
 
 LIBS += -lm
 LIBS += $(LDFLAGS)
+
+# https://stackoverflow.com/questions/34040791/no-matching-function-for-call-to-connect-qt-5-5
+CONFIG += c++11

--- a/VowelCat/main.cpp
+++ b/VowelCat/main.cpp
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 
 #include <QApplication>
+#include <QSplashScreen>
 
 extern "C" {
 #include "audio.h"

--- a/VowelCat/mainwindow.h
+++ b/VowelCat/mainwindow.h
@@ -15,6 +15,7 @@
 #include <QFileDialog>
 #include <QMainWindow>
 #include <QPushButton>
+#include <QSignalMapper>
 #include <QString>
 #include <QTimer>
 

--- a/VowelCat/phonetic-chart.h
+++ b/VowelCat/phonetic-chart.h
@@ -10,6 +10,7 @@
 
 #include <QString>
 #include <QVector>
+#include <QLabel>
 
 #include "qcustomplot.h"
 

--- a/VowelCat/plotter.h
+++ b/VowelCat/plotter.h
@@ -35,10 +35,10 @@ public:
 
     // Stop the plotter and wait for it to finish processing.
     void stop();
+    void newFormant(formant_sample_t f1, formant_sample_t f2);
 
 signals:
     void pauseSig();
-    void newFormant(formant_sample_t f1, formant_sample_t f2);
     void newSamples(size_t offset);
 
 private:

--- a/libaudio/audio.h
+++ b/libaudio/audio.h
@@ -7,7 +7,6 @@
 
 //***************************
 #include <stdlib.h>
-#define __USE_POSIX
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>


### PR DESCRIPTION
Well at least I tried. Gets pretty far but ends with this error, which I don't have enough experience to be able to debug without hours and hours of study:

```
main.cpp: In function 'int main(int, char**)':
main.cpp:73:42: error: no matching function for call to 'QObject::connect(Plotter*, void (Plotter::*)(formant_sample_t, formant_sample_t), MainWindow*, void (MainWindow::*)(formant_sample_t, formant_sample_t), Qt::ConnectionType)'
main.cpp:73:42: note: candidates are:
In file included from /usr/include/qt4/QtCore/qcoreapplication.h:45:0,
                 from /usr/include/qt4/QtGui/qapplication.h:45,
                 from /usr/include/qt4/QtGui/QApplication:1,
                 from main.cpp:7:
/usr/include/qt4/QtCore/qobject.h:204:17: note: static bool QObject::connect(const QObject*, const char*, const QObject*, const char*, Qt::ConnectionType)
/usr/include/qt4/QtCore/qobject.h:204:17: note:   no known conversion for argument 2 from 'void (Plotter::*)(formant_sample_t, formant_sample_t) {aka void (Plotter::*)(short int, short int)}' to 'const char*'
/usr/include/qt4/QtCore/qobject.h:217:17: note: static bool QObject::connect(const QObject*, const QMetaMethod&, const QObject*, const QMetaMethod&, Qt::ConnectionType)
/usr/include/qt4/QtCore/qobject.h:217:17: note:   no known conversion for argument 2 from 'void (Plotter::*)(formant_sample_t, formant_sample_t) {aka void (Plotter::*)(short int, short int)}' to 'const QMetaMethod&'
/usr/include/qt4/QtCore/qobject.h:337:13: note: bool QObject::connect(const QObject*, const char*, const char*, Qt::ConnectionType) const
/usr/include/qt4/QtCore/qobject.h:337:13: note:   candidate expects 4 arguments, 5 provided
```